### PR TITLE
Clean up thrown error on disconnect

### DIFF
--- a/src/messages/complete.ts
+++ b/src/messages/complete.ts
@@ -8,6 +8,7 @@ import {
   promisify,
 } from '../utils';
 import { MessageHandler } from './types';
+import { disconnect } from './disconnect';
 
 export const complete: MessageHandler<CompleteMessage> = (c) => async ({
   event,
@@ -58,7 +59,10 @@ export const complete: MessageHandler<CompleteMessage> = (c) => async ({
 
     await Promise.all(deletions);
   } catch (err) {
-    await promisify(() => c.onError?.(err, { event, message }));
+    await Promise.allSettled([
+      promisify(() => c.onError?.(err, { event, message })),
+      disconnect(c)({ event, message: null })
+    ]);
     await deleteConnection(event.requestContext);
   }
 };

--- a/src/messages/disconnect.ts
+++ b/src/messages/disconnect.ts
@@ -5,6 +5,10 @@ import { constructContext, getResolverAndArgs, promisify } from '../utils';
 import { MessageHandler } from './types';
 import { assign } from '../model';
 
+/* 
+ * Handler for 'disconnect' messages. 
+ * Note: Can also be called internally in the case of an error/connection close.
+ **/
 export const disconnect: MessageHandler<null> = (c) => async ({ event }) => {
   try {
     await promisify(() => c.onDisconnect?.({ event }));

--- a/src/messages/subscribe.ts
+++ b/src/messages/subscribe.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils';
 import { assign } from '../model';
 import { ServerClosure, SubscribeHandler } from '../types';
+import { disconnect } from './disconnect';
 
 export const subscribe: MessageHandler<SubscribeMessage> = (c) => async ({
   event,
@@ -95,7 +96,10 @@ export const subscribe: MessageHandler<SubscribeMessage> = (c) => async ({
       })
     );
   } catch (err) {
-    await promisify(() => c.onError?.(err, { event, message }));
+    await Promise.allSettled([
+      promisify(() => c.onError?.(err, { event, message })),
+      disconnect(c)({ event, message: null })
+    ]);
     await deleteConnection(event.requestContext);
   }
 };


### PR DESCRIPTION
## Changes

 - Calls disconnect message handler on thrown errors
 - Ensures full cleanup of server side connection close

## Clean clean-up

`Promise.allSettled` ensures that as much cleanup as possible is done - even if some fails.

This method might be a requirement for [here also](https://github.com/andyrichardson/subscriptionless/blob/4913823d881053df3c207403f86f4756b2140a32/src/messages/disconnect.ts#L63) where the first thrown error would potentially cause the lambda to shutdown before other (potentially succeeding) promises can be resolved.

<details>

<summary>Something like this could work</summary>

```js
try {
  await Promise.allSettled([
    Promise.resolve("Resolved!"),
    Promise.reject("Rejected!")
  ]).then((r) =>
    r.forEach(({ status, reason }) => {
      if (status === "rejected") {
        throw reason;
      }
    })
  );
} catch (err) {
  console.log(err);
}
```

</details>