### PR TITLE
feat: run ci on pull requests too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
 jobs:
   install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Normal push events don't run from external repositories but pr events should. Added benefit that it runs on a merge commit to master.