### PR TITLE
feat: 3 hour ttl on dynamodb tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ resources:
         KeySchema:
           - AttributeName: id
             KeyType: HASH
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
@@ -168,6 +171,9 @@ resources:
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
@@ -190,6 +196,11 @@ resource "aws_dynamodb_table" "connections-table" {
   attribute {
     name = "id"
     type = "S"
+  }
+
+  ttl {
+    attribute_name = "expiresAt"
+    enabled        = true
   }
 }
 
@@ -230,6 +241,11 @@ resource "aws_dynamodb_table" "subscriptions-table" {
     write_capacity     = 1
     read_capacity      = 1
     projection_type    = "ALL"
+  }
+
+  ttl {
+    attribute_name = "expiresAt"
+    enabled        = true
   }
 }
 ```

--- a/src/messages/connection_init.ts
+++ b/src/messages/connection_init.ts
@@ -16,6 +16,7 @@ export const connection_init: MessageHandler<ConnectionInitMessage> = (
       id: event.requestContext.connectionId!,
       requestContext: event.requestContext,
       payload: res,
+      expiresAt: Math.round(Date.now() / 1000) + 60 * 60 * 3, // three hours from now
     });
     await c.mapper.put(connection);
     return sendMessage({

--- a/src/messages/subscribe.ts
+++ b/src/messages/subscribe.ts
@@ -90,6 +90,7 @@ export const subscribe: MessageHandler<SubscribeMessage> = (c) => async ({
           connectionId: event.requestContext.connectionId!,
           connectionParams,
           requestContext: event.requestContext,
+          expiresAt: Math.round(Date.now() / 1000) + 60 * 60 * 3, // three hours from now
         });
         await c.mapper.put(subscription);
       })

--- a/src/model/Connection.ts
+++ b/src/model/Connection.ts
@@ -17,4 +17,7 @@ export class Connection {
 
   @attribute()
   payload: Record<string, string>;
+
+  @attribute({ type: 'Number' })
+  expiresAt: number;
 }

--- a/src/model/Subscription.ts
+++ b/src/model/Subscription.ts
@@ -52,4 +52,7 @@ export class Subscription {
     variableValues?: any;
     operationName?: string | null;
   };
+
+  @attribute({ type: 'Number' })
+  expiresAt: number;
 }


### PR DESCRIPTION
At a 3 hour ttl for ddb tables. Uses the field name `expiresAt`.

I'm not using serverless or terraform but I think I got the configs right.

closes #6