### PR TITLE
patch: remove graph traversal debug

### DIFF
--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -70,7 +70,6 @@ export const prepareResolvers = <T extends object | object[]>(arg: T) =>
 
 const visit = <T = object>(node: T, handler: (node: T) => any) =>
   Object.values(node).forEach((value) => {
-    console.log(value);
     if (typeof value !== 'object') {
       return;
     }


### PR DESCRIPTION
This has been bugging me more and more recently - with a large schema this makes CloudWatch logs pretty difficult to use, and spams the console in local development.