### PR TITLE
graphql-transport-ws is the protocol name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GraphQL subscriptions for AWS Lambda and API Gateway WebSockets.
 
 Have all the functionality of GraphQL subscriptions on a stateful server without the cost.
 
-> Note: This project uses the [graphql-ws protocol](https://github.com/enisdenjo/graphql-ws) under the hood.
+> Note: This project uses the [graphql-transport-ws protocol](https://github.com/enisdenjo/graphql-ws) under the hood.
 
 ## ⚠️ Limitations
 


### PR DESCRIPTION
Not to be confused with the [deprecated "graphql-ws" protocol from `subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md).